### PR TITLE
fixed delete routes for user and reaction

### DIFF
--- a/controllers/thoughtController.js
+++ b/controllers/thoughtController.js
@@ -80,8 +80,6 @@ const deleteThought = async function (req, res) {
             res.status(404).json({ message: 'No thought found with that ID.' });
         }
 
-        // Delete thought ID from user thoughts array ??
-
         res.json({ message:"Thought Deleted!" });
     } catch (err) {
         res.status(500).json(err);
@@ -112,8 +110,8 @@ const addReaction = async function (req, res) {
 const removeReaction = async function (req, res) {
     try {
         const thought = await Thought.findOneAndUpdate(
-            { _id: req.params.userId },
-            { $pull: { reaction: { reactionId: req.params.reactionId } } },
+            { _id: req.params.thoughtId },
+            { $pull: { reactions: { reactionId: req.params.reactionId } } },
             { runValidators: true, new: true }
         );
 
@@ -121,7 +119,7 @@ const removeReaction = async function (req, res) {
             res.status(404).json({ message: 'No thought found with that ID.' });
         }
 
-        res.json({ message: 'Reaction Deleted!' });
+        res.json(thought);
     } catch (err) {
         res.status(500).json(err);
     }

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -70,6 +70,8 @@ const deleteUser = async function (req, res) {
 
         // Delete associated thoughts
         await Thought.deleteMany({ _id: { $in: user.thoughts } });
+
+        res.json({ message: 'User and associated thoughts deleted!' });
     } catch (err) {
         res.status(500).json(err);
     }

--- a/models/Reaction.js
+++ b/models/Reaction.js
@@ -25,7 +25,8 @@ const reactionSchema = new Schema(
         toJSON: {
             virtuals: true,
             getters: true,
-        }
+        },
+        id: false,
     }    
 );
 


### PR DESCRIPTION
Got the routes for DELETE user and DELETE reaction working. DELETE user now deletes associated thoughts and DELETE reaction no longer throws a 500 error.